### PR TITLE
remove trailing slash from server argument

### DIFF
--- a/mobsfpy/mobsf.py
+++ b/mobsfpy/mobsf.py
@@ -14,7 +14,7 @@ class MobSF:
     """Represents a MobSF instance."""
 
     def __init__(self, apikey, server=None):
-        self.__server = server if server else DEFAULT_SERVER
+        self.__server = server.rstrip('/') if server else DEFAULT_SERVER
         self.__apikey = apikey
 
     @property


### PR DESCRIPTION
I'm removing trailing forward slash "/" from server argument because it is not needed and so it will work with or without the "/" 