### PR TITLE
Fix scan API: 're_scan' accepts '0'/'1' and not boolean

### DIFF
--- a/mobsfpy/mobsf.py
+++ b/mobsfpy/mobsf.py
@@ -46,7 +46,7 @@ class MobSF:
         post_dict = {'scan_type': scantype,
                      'file_name': filename,
                      'hash': scanhash,
-                     're_scan': rescan}
+                     're_scan': ('1' if rescan else '0') }
 
         headers = {'Authorization': self.__apikey}
 


### PR DESCRIPTION
Thanks for your python API wrapper! During usage I noticed that MobSF did not save the scan results in some cases.

See: https://github.com/MobSF/Mobile-Security-Framework-MobSF/issues/1355

The reason is, that the `re_scan` parameter only accepts `0` or `1` and not True or False. This PR fixes the behavior.